### PR TITLE
First major update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: scrattch.patchseq
 Title: Generalized Allen Institute patchseq processing
-Version: 0.1
+Version: 0.1.1
 Authors@R: 
     person(given = "Nelson",
            family = "Johansen",

--- a/README.md
+++ b/README.md
@@ -8,24 +8,26 @@ You can find a detail description of all scrattch.patchseq functions here: ![Doc
 
 Update notes are here: ![Versions](https://github.com/AllenInstitute/scrattch.patchseq/blob/main/VERSIONS.md)
 
-## Docker
+## Installation
 
-We have setup a docker environemnt for scrattch.taxonomy and scrattch.mapping that contains all the required dependencies and the current version of all scrattch packages. This docker is accessible through docker hub via: `njjai/scrattch_mapping:0.6.6`.
+### Using docker (recommended)
+We have setup a docker environment for scrattch.taxonomy, scrattch.mapping, and scrattch.patchseq that contains all the required dependencies and the current version of all scrattch packages. **See [the readme](https://github.com/AllenInstitute/scrattch/blob/master/README.md#using-docker) for [the parent scrattch package](https://github.com/AllenInstitute/scrattch) for the most up-to-date docker information.**
 
-#### HPC usage:
+### Directly from GitHub (strongly discouraged)
 
-##### Non-interactive
-`singularity exec --cleanenv docker://njjai/scrattch_mapping:0.6.6 Rscript YOUR_CODE.R`
+While we advise using the provided docker, you can also install scrattch.patchseq directly from GitHub as follows:
 
-##### Interactive
-`singularity shell --cleanenv docker://njjai/scrattch_mapping:0.6.6`
+```
+devtools::install_github("AllenInstitute/scrattch.patchseq")
+```
 
+This strategy **might not work** due to complicated dependencies. Also note that `doMC` may need to be installed manually from [HERE](https://r-forge.r-project.org/R/?group_id=947) if you use Windows. Vignettes are provided below.
 
 ## Usage examples
 
-1. [**Build and map against a small mouse PatchSeq taxonomy**](https://github.com/AllenInstitute/scrattch.patchseq/blob/main/examples/build_patchseq_taxonomy.md) This example provides the basics for updating a taxonomy to be compatible with patchseq style mapping and visualization on (internal Allen Institute) MolGen Shiny tools.
+1. [**Map against a small mouse PatchSeq taxonomy**](https://github.com/AllenInstitute/scrattch.patchseq/blob/main/examples/build_patchseq_taxonomy.md) This example provides the basics for updating a taxonomy to be compatible with patchseq style mapping and visualization on (internal Allen Institute) MolGen Shiny tools, and for collecting quality control metrics of potential use to everyone. This is a continuation of examples in scrattch.taxonomy and scrattch.mapping building data from [Tasic et al 2016](https://www.nature.com/articles/nn.4216) as reference and data from [Gouwens, Sorensen, et al 2020](https://www.sciencedirect.com/science/article/pii/S009286742031254X) as query.
 
-2. [**Build and map against a human MTG PatchSeq taxonomy**](https://github.com/AllenInstitute/scrattch.patchseq/blob/main/examples/build_MTG_patchseq_taxonomy.md) This example provides shows how to create a standard taxonomy and update it to be compatible with patchseq style mapping and visualization on (internal Allen Institute) MolGen Shiny tools. This example essentially combines examples 1 and 2 and applies them to human neocortical data sets.  Data is from Hodge et al. (2019) for human MTG and patch-seq examples are from Berg et al (2021) (layer 2-3, excitatory neurons). 
+2. [**Build and map against a human MTG PatchSeq taxonomy**](https://github.com/AllenInstitute/scrattch.patchseq/blob/main/examples/build_MTG_patchseq_taxonomy.md) This example provides shows how to create a standard taxonomy, update it to be compatible with patchseq style mapping and visualization on (internal Allen Institute) MolGen Shiny tools, and for collecting quality control metrics of potential use to everyone. This example essentially combines examples 1 and 2 and applies them to human neocortical data sets.  Reference data is from the [Seattle Alzheimer's Disease Brain Cell Atlas (SEA-AD)](https://portal.brain-map.org/explore/seattle-alzheimers-disease) project [(Gabitto, Travaglini et al., 2024)](https://www.nature.com/articles/s41593-024-01774-5) for human middle temporal gyrus (MTG) and patch-seq query data include layer 2-3, excitatory neurons from [Berg et al (2021)](https://www.nature.com/articles/s41586-021-03813-8). 
 
    
 ## Reporting issues

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,3 +1,19 @@
+## scrattch.patchseq 0.1.1
+
+Major edits to patch-seq examples 
+
+### Major changes
+* Update examples to only use public data
+* Convert human MTG example from Hodge et al to SEA-AD taxonomy
+* Change query data in mouse example from Tasic 2016 (same as reference) to Gouwens 2020
+* Update buildMappingDirectory to directly return QC metrics
+
+### Minor changes
+* Related minor bug fixes and function edits
+* Updated help files
+
+--
+
 ## scrattch.patchseq 0.1
 
 First commit

--- a/examples/build_patchseq_taxonomy.md
+++ b/examples/build_patchseq_taxonomy.md
@@ -1,44 +1,43 @@
 # Tutorial: Building a patchseq Shiny taxonomy 
 
-In this tutorial we demonstrate how to setup a patchseq Shiny taxonomy using scrattch.mapping for viewing on MolGen Shiny and running mapping algorithms against. 
+In this tutorial we demonstrate how to setup a Patchseq Shiny taxonomy using scrattch.patchseq for viewing on MolGen Shiny (AIBS internal) and running mapping algorithms against. This tutorial assumes you've already created a reference taxonomy from the [Tasic et al. 2016 study](https://www.nature.com/articles/nn.4216) by following the [scrattch.taxonomy example](https://github.com/AllenInstitute/scrattch.taxonomy/blob/main/examples/build_taxonomy.md). Query data from the [Gouwens, Sorensen, et al 2020 study](https://doi.org/10.1016/j.cell.2020.09.057) on GABAergic interneurons in primary visual cortex is used as an example. 
 
-### Required inputs:
 
-* Standard Shiny taxonomy setup following the "build_taxonomy" tutorial.
-* Query patchseq count matrix and metadata.
 
-### Additional prerequisites:
-
-* Installation of the `tasic2016data` data package [from here](https://github.com/AllenInstitute/tasic2016data/).
-* Installation of `scrattch.mapping` [from here](https://github.com/AllenInstitute/scrattch.mapping) for data mapping. 
-
-### Load in test data from Tasic 2016:
+## Load libraries and reference taxonomy
 ```R
 ## Load libraries
 library(scrattch.taxonomy)
 library(scrattch.mapping)
 library(scrattch.patchseq)
-library(tasic2016data)
+library(reticulate) # For hierarchical mapping
+cell_type_mapper <- import("cell_type_mapper") # For hierarchical mapping
 
-## Load in the tasic2016 data and wrangle as a query data set.
-query.anno = tasic_2016_anno
-query.counts = tasic_2016_counts 
-query.anno = query.anno[match(colnames(query.counts),query.anno$sample_name),]
-rownames(query.anno) = query.anno$sample_name  
-keep = query.anno$broad_type!="Unclassified"
-query.counts = query.counts[,keep]
-query.logCPM = logCPM(query.counts)
-query.anno = query.anno[keep,]
+## Specify which reference taxonomy to map against.
+## -- Replace folder and file name with correct locations
+taxonomyDir = getwd() 
+AIT.anndata = loadTaxonomy(taxonomyDir = taxonomyDir, anndata_file="Tasic2016.h5ad")
 ```
 
-### Load and setup the base taxonomy:
+### Download, read in, and format query data
 ```R
-## Standard shiny taxonomy
-# NOTE: replace 'taxonomy' location below with output folder from the "build_taxonomy" tutorial
-taxonomy = "/allen/programs/celltypes/workgroups/rnaseqanalysis/shiny/10x_seq/tasic_2016"
+## Download some example patch-seq data to map
+## -- These data are from Gouwens et al 2020 and would be replaced by your query data
+patchFolder  <- "https://data.nemoarchive.org/other/AIBS/AIBS_patchseq/transcriptome/scell/SMARTseq/processed/analysis/20200611/"
+counts_url   <- "20200513_Mouse_PatchSeq_Release_count.csv.tar"
+download.file(paste0(patchFolder,counts_url),counts_url)
+untar(counts_url)
+query.counts <- as.matrix(data.table::fread("20200513_Mouse_PatchSeq_Release_count/20200513_Mouse_PatchSeq_Release_count.csv"),rownames=1)
+query.logCPM <- logCPM(query.counts)
 
-## Load in the taxonomy
-AIT.anndata = loadTaxonomy(taxonomy, anndata_file="Tasic2016.h5ad")
+## Download metadata from Gouwens et al 2020 (to match data from scrattch.mapping tutorial) 
+## -- These data and metadata would be replaced by your query data
+download.file(paste0(patchFolder,metadata_url),metadata_url)
+metadata_url <- "20200625_patchseq_metadata_mouse.csv.tar"
+untar(metadata_url)
+query.anno   <- as.data.frame(data.table::fread("20200625_patchseq_metadata_mouse/20200625_patchseq_metadata_mouse.csv"))
+rownames(query.anno) <- query.anno$transcriptomics_sample_id
+query.anno   <- query.anno[colnames(query.counts),]
 ```
 
 ### Define off target cell types
@@ -55,12 +54,13 @@ AIT.anndata$obs$off_target = AIT.anndata$obs$broad_type_label
 levels(AIT.anndata$obs$off_target) = c(levels(AIT.anndata$obs$off_target), "Non-neuronal")
 
 ## Now lets set all Non-neuronal cells to the "Non-neuronal" off target annotation.
-AIT.anndata$obs$off_target[!is.element(AIT.anndata$obs$off_target, c("GABA-ergic Neuron","Glutamatergic Neuron", "Astrocyte"))] = "Non-neuronal"
+AIT.anndata$obs$off_target[!is.element(AIT.anndata$obs$off_target, c("GABA-ergic Neuron","Glutamatergic Neuron"))] = "Non-neuronal"
+AIT.anndata$obs$off_target <- droplevels(AIT.anndata$obs$off_target)
 ```
 
-### Build the patchseq taxonomy:
+### Build the patchseq taxonomy
 
-Now let's create a version of the taxonomy which is compatible with patchseqQC and can be filtered to remove off target cells from mapping. **You are creating a new version of the base taxonomy which can be reused by specifying the provided `mode.name` in `scrattch.taxonomy::mappingMode()` as dicusssed next.**
+Now let's create a version of the taxonomy which is compatible with patchseqQC and can be filtered to remove off target cells from mapping. **You are creating a new version of the base taxonomy which can be reused by specifying the provided `mode.name` in `scrattch.taxonomy::mappingMode()` as dicusssed next.**  Note that we also need to explicitly set the mapping mode prior to calculating MapMyCells statistics and prior to mapping to this new taxonomy mode. 
 
 ```R
 ## Setup the taxonomy for patchseqQC to infer off.target contamination
@@ -71,49 +71,50 @@ AIT.anndata = buildPatchseqTaxonomy(AIT.anndata,
                                     class.column = "off_target", ## The column by which off-target types are determined.
                                     off.target.types = c("Non-neuronal"), ## The off-target class.column labels for patchseqQC.
                                     num.markers = 50, ## Number of markers for each annotation in `class_label`
-                                    taxonomyDir = "/allen/programs/celltypes/workgroups/rnaseqanalysis/shiny/10x_seq/tasic_2016")
+                                    taxonomyDir = taxonomyDir)  ## Replace with location to store taxonomy
 ```
-The `buildPatchseqTaxonomy` function return/created the following:
+The `buildPatchseqTaxonomy` function does the following:
 
-* An updated AIT.anndata object for patchseq mapping and QC steps.
-* Created the required marker and expression files for patchseqQC and save under 'mode.name' sub-directory
+* Create a new mode of the taxonomy corresponding to a subset of clusters in the taxonomy, with baggage needed for all mapping algorithms
+* Returns updated AIT.anndata object to allow for patchseq mapping as well as for the QC steps below.
 
-### Set scrattch.mapping mode
-
-Now we will set scrattch.mapping to use only cells not in the off.target.types, this will filter the taxonomy and adjust the dendrogram to remove any `cluster` in `off.target.types`.
-
+### Map against the patchseq taxonomy
 ```R
+## Set scrattch.mapping mode - DO NOT SKIP THIS STEP
 AIT.anndata = mappingMode(AIT.anndata, mode="patchseq")
-```
 
-### Map against the patchseq taxonomy:
-```R
 # This function is part of the 'scrattch.mapping' library
 query.mapping = taxonomy_mapping(AIT.anndata= AIT.anndata,
-                                  query.data = query.logCPM,
-                                  corr.map   = TRUE, # Flags for which mapping algorithms to run
-                                  tree.map   = TRUE, 
-                                  seurat.map = FALSE, 
-                                  hierarchical.map = FALSE, ## Not that this will not work correctly with the patchseq mode. TODO.
-                                  label.cols = c("cluster_label", "broad_type_label")) # Columns to map against from AIT.anndata$obs
-## If you want the mapping data.frame from the S4 mappingClass
-mapping.results = getMappingResults(query.mapping, scores=FALSE)
+                                 query.data = query.logCPM,
+                                 corr.map   = TRUE, # Flags for which mapping algorithms to run
+                                 tree.map   = TRUE, 
+                                 seurat.map = TRUE, 
+                                 hierarchical.map = TRUE)
+
+## If you want the mapping data.frame and associated scores from the S4 mappingClass
+mapping.results = getMappingResults(query.mapping, scores=TRUE)
 ```
 
-### Determine patchseq contamination with PatchseqQC:
-```R
-patchseq.qc = applyPatchseqQC(AIT.anndata, ## A patchseq taxonomy object.
-                                query.counts, ## Counts are required here.
-                                query.anno, ## Query annotations to add PatchSeqQC onto.
-                                verbose=FALSE)
-```
+### QC patch-seq data and create shiny directory
 
-### Setup the patchseq Shiny taxonomy files for MolGen Shiny:
+This section performs additional query data QC and then outputs the files necessary for visualization of Patch-seq data with molgen-shiny tools (AIBS internal) into a folder. If `return.metrics = TRUE`, this function also returns an updated annotation table that includes original metadata, mapping results, and all of the additional metrics and statistics described below.
+
+More specifically, the function buildMappingDirectory:
+* Creates a new folder to deposit all relevant query files (this is what you copy into the the molgen-shiny directory)
+* Performs patchSeqQC on the query data to define Normalized Marker Sum (NMS) and other QC scores (see https://github.com/PavlidisLab/patchSeqQC for details)
+* Calculates KL Divergence and associated Core/I1/I2/I3/PoorQ calls used to help assess Patch-seq quality
+* Calculates and outputs tree mapping probabilities of every cell mapping to every cluster and tree node
+* Calculates and outputs UMAP coordinates for query cells integrated into reference UMAP space
+* Optionally returns the updated metadata file
+
 ```R
-buildMappingDirectory(AIT.anndata    = AIT.anndata, 
-                      mappingFolder  = '/allen/programs/celltypes/workgroups/rnaseqanalysis/shiny/10x_seq/tasic_2016/patchseq_mapping',
-                      query.data     = query.counts, ## Counts are required here.
-                      query.metadata = query.anno,
-                      query.mapping  = query.mapping, ## This has to be an S4 mappingClass from scrattch.mapping.
-                      doPatchseqQC   = FALSE)  ## Set to FALSE if not needed or if buildPatchseqTaxonomy was not run.
+updated.query.anno <- buildMappingDirectory(
+    AIT.anndata    = AIT.anndata, 
+    mappingFolder  = file.path(taxonomyDir,"patchseq"),  ## Put the correct file path for output here
+    query.data     = query.counts, ## Counts are required here (NOT cpm or logCPM)
+    query.metadata = query.anno,
+    query.mapping  = query.mapping, ## This has to be an S4 mappingClass from scrattch.mapping.
+    doPatchseqQC   = TRUE,  ## Set to FALSE if not needed or if buildPatchseqTaxonomy was not run.
+    return.metrics = TRUE  ## Set to TRUE to return the updated metrics table
+)
 ```

--- a/man/buildMappingDirectory.Rd
+++ b/man/buildMappingDirectory.Rd
@@ -13,6 +13,7 @@ buildMappingDirectory(
   doPatchseqQC = TRUE,
   metadata_names = NULL,
   min.confidence = 0.7,
+  return.metrics = FALSE,
   verbose = TRUE
 )
 }
@@ -32,6 +33,8 @@ buildMappingDirectory(
 \item{metadata_names}{An optional named character vector where the vector NAMES correspond to columns in the metadata matrix and the vector VALUES correspond to how these metadata should be displayed in Shiny. This is used for writing the desc.feather file later.}
 
 \item{min.confidence}{Probability below which a cell cannot be assigned to a cell type (default 0.7).  In other words, if no cell types have probabilities greater than resolution.index, then the assigned cluster will be an internal node of the dendrogram.}
+
+\item{return.metrics}{If TRUE (default=FALSE) will return an updated query.metadata data frame with additional metrics calculated as part of this function. Otherwise, these values are available in 'anno.feather'.}
 
 \item{verbose}{Should detail logging be printed to the screen?
 

--- a/man/buildPatchseqTaxonomy.Rd
+++ b/man/buildPatchseqTaxonomy.Rd
@@ -14,6 +14,8 @@ buildPatchseqTaxonomy(
   subclass.subsample = 100,
   num.markers = 50,
   taxonomyDir = file.path(AIT.anndata$uns$taxonomyDir),
+  addMapMyCells = TRUE,
+  hierarchy = AIT.anndata$uns$hierarchy,
   ...
 )
 }
@@ -36,6 +38,10 @@ buildPatchseqTaxonomy(
 
 \item{taxonomyDir}{The location to save shiny output (default = current working directory).}
 
+\item{addMapMyCells}{If TRUE (default), will also prep this mode of the taxonomy for hierarchical mapping}
+
+\item{hierarchy}{Column names of annotations to map against with hierarchical mapping.  Note that this only works for metadata that represent clusters or groups of clusters (e.g., subclass, supertype, neighborhood, class). Will default to whatever is in AIT.anndata$uns$hierarchy and is required if addMapMyCells=TRUE}
+
 \item{...}{Additional variables to be passed to \code{addDendrogramMarkers}
 
 The following variables are added to AIT.anndata$uns:
@@ -48,7 +54,6 @@ $QC_markers[\link{mode.name}]
 ...$classBr,
 ...$subclassF,
 ...$allMarkers
-...$de_genes
 $memb[\link{mode.name}]
 ...$memb.ref,
 ...$map.df.ref}

--- a/scrattch.patchseq_FORK.Rproj
+++ b/scrattch.patchseq_FORK.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/vignettes/go_to_examples.Rmd
+++ b/vignettes/go_to_examples.Rmd
@@ -7,4 +7,4 @@ vignette: >
   \usepackage[utf8]{inputenc} 
 ---
   
-Vignettes are located on the main website for scrattch.taxonomy: https://github.com/AllenInstitute/scrattch.taxonomy
+Vignettes are located on the main website for scrattch.patchseq: https://github.com/AllenInstitute/scrattch.patchseq

--- a/vignettes/go_to_examples.html
+++ b/vignettes/go_to_examples.html
@@ -239,7 +239,7 @@ code > span.er { color: #a61717; background-color: #e3d2d2; }
 
 
 
-<p>Vignettes are located on the main website for scrattch.taxonomy: <a href="https://github.com/AllenInstitute/scrattch.taxonomy" class="uri">https://github.com/AllenInstitute/scrattch.taxonomy</a></p>
+<p>Vignettes are located on the main website for scrattch.patchseq: <a href="https://github.com/AllenInstitute/scrattch.patchseq" class="uri">https://github.com/AllenInstitute/scrattch.patchseq</a></p>
 
 
 


### PR DESCRIPTION
## scrattch.patchseq 0.1.1

Major edits to patch-seq examples 

### Major changes
* Update examples to only use public data
* Convert human MTG example from Hodge et al to SEA-AD taxonomy
* Change query data in mouse example from Tasic 2016 (same as reference) to Gouwens 2020
* Update buildMappingDirectory to directly return QC metrics

### Minor changes
* Related minor bug fixes and function edits
* Updated help files