### PR TITLE
Updates to improve correlation mapping

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: scrattch.patchseq
 Title: Generalized Allen Institute patchseq processing
-Version: 0.1.1
+Version: 0.7.1
 Authors@R: 
     person(given = "Nelson",
            family = "Johansen",

--- a/README.md
+++ b/README.md
@@ -8,24 +8,26 @@ You can find a detail description of all scrattch.patchseq functions here: ![Doc
 
 Update notes are here: ![Versions](https://github.com/AllenInstitute/scrattch.patchseq/blob/main/VERSIONS.md)
 
-## Docker
+## Installation
 
-We have setup a docker environemnt for scrattch.taxonomy and scrattch.mapping that contains all the required dependencies and the current version of all scrattch packages. This docker is accessible through docker hub via: `njjai/scrattch_mapping:0.6.6`.
+### Using docker (recommended)
+We have setup a docker environment for scrattch.taxonomy, scrattch.mapping, and scrattch.patchseq that contains all the required dependencies and the current version of all scrattch packages. **See [the readme](https://github.com/AllenInstitute/scrattch/blob/master/README.md#using-docker) for [the parent scrattch package](https://github.com/AllenInstitute/scrattch) for the most up-to-date docker information.**
 
-#### HPC usage:
+### Directly from GitHub (strongly discouraged)
 
-##### Non-interactive
-`singularity exec --cleanenv docker://njjai/scrattch_mapping:0.6.6 Rscript YOUR_CODE.R`
+While we advise using the provided docker, you can also install scrattch.patchseq directly from GitHub as follows:
 
-##### Interactive
-`singularity shell --cleanenv docker://njjai/scrattch_mapping:0.6.6`
+```
+devtools::install_github("AllenInstitute/scrattch.patchseq")
+```
 
+This strategy **might not work** due to complicated dependencies. Also note that `doMC` may need to be installed manually from [HERE](https://r-forge.r-project.org/R/?group_id=947) if you use Windows. Vignettes are provided below.
 
 ## Usage examples
 
-1. [**Build and map against a small mouse PatchSeq taxonomy**](https://github.com/AllenInstitute/scrattch.patchseq/blob/main/examples/build_patchseq_taxonomy.md) This example provides the basics for updating a taxonomy to be compatible with patchseq style mapping and visualization on (internal Allen Institute) MolGen Shiny tools.
+1. [**Map against a small mouse PatchSeq taxonomy**](https://github.com/AllenInstitute/scrattch.patchseq/blob/main/examples/build_patchseq_taxonomy.md) This example provides the basics for updating a taxonomy to be compatible with patchseq style mapping and visualization on (internal Allen Institute) MolGen Shiny tools, and for collecting quality control metrics of potential use to everyone. This is a continuation of examples in scrattch.taxonomy and scrattch.mapping building data from [Tasic et al 2016](https://www.nature.com/articles/nn.4216) as reference and data from [Gouwens, Sorensen, et al 2020](https://www.sciencedirect.com/science/article/pii/S009286742031254X) as query.
 
-2. [**Build and map against a human MTG PatchSeq taxonomy**](https://github.com/AllenInstitute/scrattch.patchseq/blob/main/examples/build_MTG_patchseq_taxonomy.md) This example provides shows how to create a standard taxonomy and update it to be compatible with patchseq style mapping and visualization on (internal Allen Institute) MolGen Shiny tools. This example essentially combines examples 1 and 2 and applies them to human neocortical data sets.  Data is from Hodge et al. (2019) for human MTG and patch-seq examples are from Berg et al (2021) (layer 2-3, excitatory neurons). 
+2. [**Build and map against a human MTG PatchSeq taxonomy**](https://github.com/AllenInstitute/scrattch.patchseq/blob/main/examples/build_MTG_patchseq_taxonomy.md) This example provides shows how to create a standard taxonomy, update it to be compatible with patchseq style mapping and visualization on (internal Allen Institute) MolGen Shiny tools, and for collecting quality control metrics of potential use to everyone. This example essentially combines examples 1 and 2 and applies them to human neocortical data sets.  Reference data is from the [Seattle Alzheimer's Disease Brain Cell Atlas (SEA-AD)](https://portal.brain-map.org/explore/seattle-alzheimers-disease) project [(Gabitto, Travaglini et al., 2024)](https://www.nature.com/articles/s41593-024-01774-5) for human middle temporal gyrus (MTG) and patch-seq query data include layer 2-3, excitatory neurons from [Berg et al (2021)](https://www.nature.com/articles/s41586-021-03813-8). 
 
    
 ## Reporting issues

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,4 +1,18 @@
-## scrattch.patchseq 0.1.1
+## scrattch.patchseq v0.7.1
+
+Updates to improve correlation mapping
+
+### Major changes
+
+### Minor changes
+* Synchronized versions between scrattch.taxonomy, scrattch.mapping, an scrattch.patchseq
+* Added an option for inputting high variable genes in `buildPatchseqTaxonomy`
+* Fix cluster names in medianExpr for `buildPatchseqTaxonomy` to fix corMap
+* Minor updates to the examples and documentation improvements
+
+--
+
+## scrattch.patchseq v0.1.1
 
 Major edits to patch-seq examples 
 
@@ -14,6 +28,6 @@ Major edits to patch-seq examples
 
 --
 
-## scrattch.patchseq 0.1
+## scrattch.patchseq v0.1
 
 First commit

--- a/man/buildPatchseqTaxonomy.Rd
+++ b/man/buildPatchseqTaxonomy.Rd
@@ -6,6 +6,7 @@
 \usage{
 buildPatchseqTaxonomy(
   AIT.anndata,
+  variable.genes = NULL,
   mode.name = "patchseq",
   subsample = 100,
   subclass.column = "subclass_label",
@@ -22,13 +23,15 @@ buildPatchseqTaxonomy(
 \arguments{
 \item{AIT.anndata}{A reference taxonomy anndata object.}
 
+\item{variable.genes}{Set of variable genes used for correlation and Seurat mapping. We recommend providing this gene set, but if not provided the gene set will default to the highly.variable.genes from mode="standard" (not recommended).  This can also be set after the fact using \code{updateHighlyVariableGenes}.}
+
 \item{mode.name}{A name to identify the new taxonomy version.}
 
-\item{subsample}{The number of cells to retain per cluster (default = 100).}
+\item{subsample}{The number of cells to retain per cluster (default = 100). See details.}
 
-\item{subclass.column}{Column name corresponding to the moderate-resolution cell types used for the cell types of interest (default = "subclass_label").}
+\item{subclass.column}{Column name corresponding to the moderate-resolution cell types used for the cell types of interest (default = "subclass_label"). See details.}
 
-\item{class.column}{Column name corresponding to the low-resolution cell types used for the off-target cell types (default = "class_label").}
+\item{class.column}{Column name corresponding to the low-resolution cell types used for the off-target cell types (default = "class_label"). See details.}
 
 \item{off.target.types}{A character vector of off-target (also known as 'contamination') cell types.  This must include at least one of the cell types found in "class.column" and/or "subclass.column" (both columns are checked)}
 
@@ -44,6 +47,16 @@ buildPatchseqTaxonomy(
 
 \item{...}{Additional variables to be passed to \code{addDendrogramMarkers}
 
+\strong{How filtering works}
+
+Currently taxonomies are subsetted (or 'filtered') using two methods.  First, at most a random set of \code{subsample} cells are included per cluster (and therefore the rest of the cells per cluster are filtered).  If you do not want to subsample, then set subsample=Inf.  Second, off target clusters are removed. More specifically, any cells with values of \code{off.target.types} in either \code{subclass.column} or \code{class.column} are removed. Note that cells labeled as TRUE in the filter are the ones REMOVED.
+
+\strong{Notes on PatchseqQC}
+
+PatchseqQC requires cell types defined at two resolutions to work, currently defined in the class \code{subclass.column} and \code{class.column} for the higher and lower-resolution cell types respectively. PatchseqQC has the concept of on target vs. off target gene expression.  For on target types, it uses the lower resolution types and for off-target types it uses the higher-resolution types. QC metrics can then estimate the quality of the cell along with how much contamination there is from other types of cells. PatchseqQC isn't called in this function, but several of the additions listed below are input files required to call it later.
+
+\strong{Additions to AIT.anndata}
+
 The following variables are added to AIT.anndata$uns:
 $dend[\link{mode.name}]
 $filter[\link{mode.name}]
@@ -56,7 +69,10 @@ $QC_markers[\link{mode.name}]
 ...$allMarkers
 $memb[\link{mode.name}]
 ...$memb.ref,
-...$map.df.ref}
+...$map.df.ref
+
+The following variable is added to AIT.anndata$var
+$highly_variable_genes_{AIT.anndata$uns$mode}}
 }
 \value{
 AIT.anndata An updated AIT.anndata variable with the above content added to AIT.anndata$uns for the relevant mode.name.


### PR DESCRIPTION
## scrattch.patchseq v0.7.1

Updates to improve correlation mapping

### Major changes

### Minor changes
* Synchronized versions between scrattch.taxonomy, scrattch.mapping, an scrattch.patchseq
* Added an option for inputting high variable genes in `buildPatchseqTaxonomy`
* Fix cluster names in medianExpr for `buildPatchseqTaxonomy` to fix corMap
* Minor updates to the examples and documentation improvements